### PR TITLE
Fixing SecureConnectionStart bigger than zero condition

### DIFF
--- a/looker/web-block-old-lookml/05_scratch_timing_context.view.lookml
+++ b/looker/web-block-old-lookml/05_scratch_timing_context.view.lookml
@@ -59,7 +59,6 @@
           AND pt.fetch_start IS NOT NULL AND pt.fetch_start > 0
           AND pt.domain_lookup_start IS NOT NULL AND pt.domain_lookup_start > 0
           AND pt.domain_lookup_end IS NOT NULL AND pt.domain_lookup_end > 0
-          AND pt.secure_connection_start IS NOT NULL AND pt.secure_connection_start > 0
           -- connect_start is either 0 or NULL
           AND pt.connect_end IS NOT NULL AND pt.connect_end > 0
           AND pt.request_start IS NOT NULL AND pt.request_start > 0

--- a/looker/web-block/05_scratch_timing_context.view.lkml
+++ b/looker/web-block/05_scratch_timing_context.view.lkml
@@ -58,7 +58,6 @@ view: scratch_pv_05 {
           AND pt.fetch_start IS NOT NULL AND pt.fetch_start > 0
           AND pt.domain_lookup_start IS NOT NULL AND pt.domain_lookup_start > 0
           AND pt.domain_lookup_end IS NOT NULL AND pt.domain_lookup_end > 0
-          AND pt.secure_connection_start IS NOT NULL AND pt.secure_connection_start > 0
           -- connect_start is either 0 or NULL
           AND pt.connect_end IS NOT NULL AND pt.connect_end > 0
           AND pt.request_start IS NOT NULL AND pt.request_start > 0

--- a/redshift/sql/01-page-views/05-timing-context.sql
+++ b/redshift/sql/01-page-views/05-timing-context.sql
@@ -62,7 +62,6 @@ AS (
       AND pt.fetch_start IS NOT NULL AND pt.fetch_start > 0
       AND pt.domain_lookup_start IS NOT NULL AND pt.domain_lookup_start > 0
       AND pt.domain_lookup_end IS NOT NULL AND pt.domain_lookup_end > 0
-      AND pt.secure_connection_start IS NOT NULL AND pt.secure_connection_start > 0
       -- connect_start is either 0 or NULL
       AND pt.connect_end IS NOT NULL AND pt.connect_end > 0
       AND pt.request_start IS NOT NULL AND pt.request_start > 0

--- a/sql-runner/sql/web-model/01-page-views/05-timing-context.sql
+++ b/sql-runner/sql/web-model/01-page-views/05-timing-context.sql
@@ -62,7 +62,6 @@ AS (
       AND pt.fetch_start IS NOT NULL AND pt.fetch_start > 0
       AND pt.domain_lookup_start IS NOT NULL AND pt.domain_lookup_start > 0
       AND pt.domain_lookup_end IS NOT NULL AND pt.domain_lookup_end > 0
-      AND pt.secure_connection_start IS NOT NULL AND pt.secure_connection_start > 0
       -- connect_start is either 0 or NULL
       AND pt.connect_end IS NOT NULL AND pt.connect_end > 0
       AND pt.request_start IS NOT NULL AND pt.request_start > 0


### PR DESCRIPTION
While conducting pageview performance analysis on our webpages, we noticed that several pageviews events carried many null values in their information. Further investigating, we came across the condition  
in the timing context table calculations requiring secure_connection_start to be bigger than 0.
Apparently, on a user first access to a page the performanceTiming event carries a value for secure_connection_start timing, but on later access this value is set to 0. As a consequence we had approximately only 50% of pageview events with load performance information.
Removing the condition of the value being bigger than 0 should fix this problem.